### PR TITLE
Fix typo in factorial example

### DIFF
--- a/examples/maths.at
+++ b/examples/maths.at
@@ -7,7 +7,7 @@ fn print_factorials n is
 	@ if = 0 n
 		null
 		print_factorials - n 1
-	print + "fact(" + str n + ") = " str fact n
+	print + "fact(" + str n + ") = " str factorial n
 
 fn count_to n is
 	if = n 0


### PR DESCRIPTION
```python
CannotFind("fact")
```
→
```python
Factorials:
fact(0) = 1
fact(1) = 1
fact(2) = 2
fact(3) = 6
fact(4) = 24
fact(5) = 120
fact(6) = 720
fact(7) = 5040
fact(8) = 40320
fact(9) = 362880
fact(10) = 3628800
Finished!
```