### PR TITLE
Remove duplicate definition of "!"

### DIFF
--- a/src/atto/core.at
+++ b/src/atto/core.at
@@ -74,14 +74,6 @@ fn @ x y is
 	# "Evaluate to only the first argument"
 	# y x
 
-fn ! x is
-	# "Negate a boolean value"
-	if = true x
-		false
-	if = false x
-		true
-	x
-
 fn wrap x is
 	# "Wrap a value in a list"
 	tail pair null x


### PR DESCRIPTION
The function "!" is first defined on line 22, and doesn't need to be defined again (unless you want to keep the comment).